### PR TITLE
build: refactor application packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,24 @@ RUN npm install -g fsh-sushi
 
 WORKDIR /build
 
-COPY . .
+COPY _genonce.sh _genonce.sh
+COPY _updatePublisher.sh _updatePublisher.sh
+COPY input input
+COPY ig.ini ig.ini
+COPY sushi-config.yaml sushi-config.yaml
+COPY package-list.json package-list.json
 
 RUN ./_updatePublisher.sh -y || echo "ok"
 
 RUN ./_genonce.sh -y
 
-FROM scratch
+FROM alpine:3.13
+
+WORKDIR /app
+
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
 COPY --from=build-image /build /app
-COPY --from=build-image /bin/sh /bin/sh
 
-CMD /bin/sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Trace execution
+[[ "${DEBUG}" ]] && set -x
+
+export STATIC_ROOT="${STATIC_ROOT:-/var/www/static/osiris-ig}"
+
+rm -rf "${STATIC_ROOT}" && cp -r ./output "${STATIC_ROOT}"


### PR DESCRIPTION
the osiris application broke down every time we tried to deploy an other service. I used the same packaging method as with the new pyrog (using a single static volume for all frontend apps) to avoid this issue.

I'm trying to deploy to dev atm